### PR TITLE
feat: disable slide up transition when scrolling up

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,7 +132,6 @@ body {
   opacity: 0;
 }
 .slide-up[data-animated="true"] {
-  opacity: 0;
   animation: slide-up-a-little 0.3s ease-in-out forwards;
 }
 

--- a/src/app/home/(services)/ServiceOffer.tsx
+++ b/src/app/home/(services)/ServiceOffer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { content } from "@/content";
+import { useFadeInOnScroll } from "@/hooks/useFadeInOnScroll";
 import { useInView } from "@/hooks/useInView";
 import { Button, Heading, Text, VStack } from "@chakra-ui/react";
 import Link from "next/link";
@@ -9,14 +10,10 @@ import { FC } from "react";
 const ServiceOffer: FC = () => {
   const servicesInView = useInView(0.25);
 
+  const fadeProps = useFadeInOnScroll(servicesInView.inView);
+
   return (
-    <VStack
-      as={"section"}
-      ref={servicesInView.ref}
-      className={"slide-up"}
-      data-animated={servicesInView.inView}
-      gap={4}
-    >
+    <VStack as={"section"} ref={servicesInView.ref} gap={4} {...fadeProps}>
       <Heading
         as={"h2"}
         size={{ base: "5xl", md: "7xl" }}

--- a/src/app/home/(services)/Technologies.tsx
+++ b/src/app/home/(services)/Technologies.tsx
@@ -2,6 +2,7 @@
 
 import Searchbar from "@/components/ui/searchbar";
 import { content, TechTag, techTags } from "@/content";
+import { useFadeInOnScroll } from "@/hooks/useFadeInOnScroll";
 import { useInView } from "@/hooks/useInView";
 import {
   Badge,
@@ -24,8 +25,12 @@ const tagToColor: Record<TechTag, string> = {
 
 const Technologies: FC = () => {
   const techsInView = useInView(0.25);
+
   const [filter, setFilter] = useState<TechTag>();
   const [search, setSearch] = useState("");
+
+  const fadeProps = useFadeInOnScroll(techsInView.inView);
+
   const reset = () => {
     setFilter(undefined);
     setSearch("");
@@ -43,13 +48,7 @@ const Technologies: FC = () => {
 
   const theContent = content.services.technologies;
   return (
-    <VStack
-      as={"section"}
-      ref={techsInView.ref}
-      className={"slide-up"}
-      data-animated={techsInView.inView}
-      gap={8}
-    >
+    <VStack as={"section"} ref={techsInView.ref} gap={8} {...fadeProps}>
       <Heading as={"h4"} size={"3xl"}>
         {theContent.heading}
       </Heading>

--- a/src/app/home/Contact.tsx
+++ b/src/app/home/Contact.tsx
@@ -5,10 +5,14 @@ import { useInView } from "@/hooks/useInView";
 import { Grid, Heading, VStack } from "@chakra-ui/react";
 import ContactForm from "./ContactForm";
 import ContactMailTo from "./ContactMailTo";
+import { useFadeInOnScroll } from "@/hooks/useFadeInOnScroll";
 
 const Contact = () => {
   // not sure why but putting inView on the root VStack of this component, I get a double scrollbar when scrolling down to Contact. Moving it to the children of the root VStack fixes this.
   const inView = useInView(0.25);
+
+  const fadeProps = useFadeInOnScroll(inView.inView);
+
   return (
     <VStack
       gap={8}
@@ -17,11 +21,7 @@ const Contact = () => {
       as={"article"}
       id={content.contact.id}
     >
-      <VStack
-        ref={inView.ref}
-        className={"slide-up"}
-        data-animated={inView.inView}
-      >
+      <VStack ref={inView.ref} {...fadeProps}>
         <Heading
           as={"h2"}
           size={{ base: "5xl", md: "7xl" }}
@@ -40,8 +40,7 @@ const Contact = () => {
         }}
         gap={16}
         ref={inView.ref}
-        className={"slide-up"}
-        data-animated={inView.inView}
+        {...fadeProps}
       >
         <ContactMailTo />
         <ContactForm />

--- a/src/app/home/ProjectCard.tsx
+++ b/src/app/home/ProjectCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { content } from "@/content";
+import { useFadeInOnScroll } from "@/hooks/useFadeInOnScroll";
 import { useInView } from "@/hooks/useInView";
 import { Card, VStack } from "@chakra-ui/react";
 import Image from "next/image";
@@ -12,15 +13,16 @@ const ProjectCard: FC<{
 }> = ({ project }) => {
   const { ref, inView } = useInView(0.5);
 
+  const fadeProps = useFadeInOnScroll(inView);
+
   return (
     <Link
       href={project.externalLink}
       key={project.title}
-      className={"project-grid-item slide-up"}
       target={"_blank"}
       rel={"noopener noreferrer"}
-      data-animated={inView}
       ref={ref}
+      className={"project-grid-item"}
     >
       <Card.Root
         variant={"elevated"}
@@ -30,6 +32,7 @@ const ProjectCard: FC<{
         pt={4}
         transition={"0.3s"}
         _hover={{ scale: 1.1 }}
+        {...fadeProps}
       >
         <Card.Header position={"relative"} mx={4}>
           <Image

--- a/src/app/home/Projects.tsx
+++ b/src/app/home/Projects.tsx
@@ -4,9 +4,13 @@ import { content } from "@/content";
 import { useInView } from "@/hooks/useInView";
 import { Grid, Heading, VStack } from "@chakra-ui/react";
 import ProjectCard from "./ProjectCard";
+import { useFadeInOnScroll } from "@/hooks/useFadeInOnScroll";
 
 const Projects = () => {
   const headingInView = useInView(0.75);
+
+  const fadeProps = useFadeInOnScroll(headingInView.inView);
+
   return (
     <VStack
       gap={16}
@@ -20,8 +24,7 @@ const Projects = () => {
         size={{ base: "5xl", md: "7xl" }}
         textAlign={"center"}
         ref={headingInView.ref}
-        className={"slide-up"}
-        data-animated={headingInView.inView}
+        {...fadeProps}
       >
         {content.latestWork.title}
       </Heading>

--- a/src/app/home/Testimonial.tsx
+++ b/src/app/home/Testimonial.tsx
@@ -2,18 +2,23 @@
 
 import { content } from "@/content";
 import { useInView } from "@/hooks/useInView";
+import { useFadeInOnScroll } from "@/hooks/useFadeInOnScroll";
 import { Button, Heading, VStack } from "@chakra-ui/react";
 import Link from "next/link";
-import TestamonialCard from "./TestamonialCard";
+import TestimonialCard from "./TestimonialCard";
 
-const Testamonials = () => {
+const Testimonials = () => {
   const headingInView = useInView(0.75);
   const buttonInView = useInView(0.75);
+
+  const fadePropsHeading = useFadeInOnScroll(headingInView.inView);
+  const fadePropsButton = useFadeInOnScroll(buttonInView.inView);
+
   return (
     <VStack
       gap={16}
       pb={16}
-      id={content.testamonials.id}
+      id={content.testimonials.id}
       minH={"100svh"}
       as={"section"}
     >
@@ -22,15 +27,14 @@ const Testamonials = () => {
         size={{ base: "5xl", md: "7xl" }}
         textAlign={"center"}
         ref={headingInView.ref}
-        className={"slide-up"}
-        data-animated={headingInView.inView}
+        {...fadePropsHeading}
       >
-        {content.testamonials.title}
+        {content.testimonials.title}
       </Heading>
       <VStack gap={16}>
         {/* Desktop */}
-        {content.testamonials.cards.map((t, i) => (
-          <TestamonialCard testamonial={t} index={i} key={t.name} gap={16} />
+        {content.testimonials.cards.map((t, i) => (
+          <TestimonialCard testimonial={t} index={i} key={t.name} gap={16} />
         ))}
       </VStack>
       <Button
@@ -40,19 +44,18 @@ const Testamonials = () => {
         variant={"outline"}
         minW={{ md: 180, base: "full" }}
         ref={buttonInView.ref}
-        data-animated={buttonInView.inView}
-        className={"slide-up"}
+        {...fadePropsButton}
       >
         <Link
-          href={content.testamonials.linkedInRecommendations.href}
+          href={content.testimonials.linkedInRecommendations.href}
           target={"_blank"}
           referrerPolicy={"no-referrer"}
         >
-          {content.testamonials.linkedInRecommendations.label}
+          {content.testimonials.linkedInRecommendations.label}
         </Link>
       </Button>
     </VStack>
   );
 };
 
-export default Testamonials;
+export default Testimonials;

--- a/src/app/home/TestimonialCard.tsx
+++ b/src/app/home/TestimonialCard.tsx
@@ -2,22 +2,25 @@
 
 import AvatarWithText from "@/components/ui/avatar-with-text";
 import { content } from "@/content";
+import { useFadeInOnScroll } from "@/hooks/useFadeInOnScroll";
 import { useInView } from "@/hooks/useInView";
 import { HStack, Separator, Text, VStack } from "@chakra-ui/react";
 import { FC } from "react";
 
 type Props = {
-  testamonial: (typeof content.testamonials.cards)[number];
+  testimonial: (typeof content.testimonials.cards)[number];
   index: number;
   gap: number;
 };
 
-const TestamonialCard: FC<Props> = ({ testamonial, index, gap }) => {
+const TestimonialCard: FC<Props> = ({ testimonial, index, gap }) => {
   const { ref, inView } = useInView(0.5);
   const even = index % 2 === 0;
 
+  const fadeProps = useFadeInOnScroll(inView);
+
   return (
-    <VStack ref={ref} data-animated={inView} className={"slide-up"} gap={gap}>
+    <VStack ref={ref} gap={gap} {...fadeProps}>
       {index !== 0 && (
         <Separator
           variant={"solid"}
@@ -34,17 +37,17 @@ const TestamonialCard: FC<Props> = ({ testamonial, index, gap }) => {
         flexDir={even ? "row" : "row-reverse"}
       >
         <AvatarWithText
-          testamonial={testamonial}
+          testimonial={testimonial}
           flexDir={{ md: "column", base: even ? "row" : "row-reverse" }}
         />
         <Text
           as={"blockquote"}
           maxW={"xl"}
-          dangerouslySetInnerHTML={{ __html: testamonial.quote }}
+          dangerouslySetInnerHTML={{ __html: testimonial.quote }}
         ></Text>
       </HStack>
     </VStack>
   );
 };
 
-export default TestamonialCard;
+export default TestimonialCard;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from "next";
 import Footer from "./common/Footer";
 import Navbar from "./common/Navbar";
 import "./globals.css";
+import { ScrollProvider } from "@/contexts/ScrollContext";
 
 export const metadata: Metadata = {
   title: content.htmlMeta.title,
@@ -22,15 +23,17 @@ export default function RootLayout({
     <html suppressHydrationWarning lang={"en"}>
       <body>
         <Provider>
-          <Grid
-            templateRows={"var(--navbar-height) 1fr min-content"}
-            pb={4}
-            minH={"100svh"}
-          >
-            <Navbar />
-            {children}
-            <Footer />
-          </Grid>
+          <ScrollProvider>
+            <Grid
+              templateRows={"var(--navbar-height) 1fr min-content"}
+              pb={4}
+              minH={"100svh"}
+            >
+              <Navbar />
+              {children}
+              <Footer />
+            </Grid>
+          </ScrollProvider>
         </Provider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@ import Contact from "./home/Contact";
 import HeroBanner from "./home/HeroBanner";
 import Projects from "./home/Projects";
 import Services from "./home/Services";
-import Testamonials from "./home/Testamonial";
+import Testimonials from "./home/Testimonial";
 import SeoSchemaMarkup from "./SchemaMarkup";
 
 export const metadata: Metadata = {
@@ -21,7 +21,7 @@ const HomePage = () => {
       <VStack as={"main"} px={{ md: 12, base: 4 }}>
         <HeroBanner />
         <Services />
-        <Testamonials />
+        <Testimonials />
         <Projects />
         <Contact />
       </VStack>

--- a/src/components/ui/avatar-with-text.tsx
+++ b/src/components/ui/avatar-with-text.tsx
@@ -4,24 +4,24 @@ import { StackProps, Text, VStack } from "@chakra-ui/react";
 import { FC } from "react";
 
 type Props = {
-  testamonial: (typeof content.testamonials.cards)[number];
+  testimonial: (typeof content.testimonials.cards)[number];
   flexDir?: StackProps["flexDir"];
 };
 
-const AvatarWithText: FC<Props> = ({ testamonial, flexDir }) => {
+const AvatarWithText: FC<Props> = ({ testimonial, flexDir }) => {
   return (
     <VStack as={"figure"} flexDir={flexDir} gapX={4}>
       <Avatar
-        name={testamonial.name}
-        src={testamonial.img.src}
-        alt={testamonial.img.alt}
+        name={testimonial.name}
+        src={testimonial.img.src}
+        alt={testimonial.img.alt}
         size={"2xl"}
       ></Avatar>
       <Text as={"figcaption"} textAlign={"center"}>
-        {testamonial.name}
+        {testimonial.name}
         <br />
         <Text color={"dimgray"}>
-          {testamonial.role} / {testamonial.company}
+          {testimonial.role} / {testimonial.company}
         </Text>
       </Text>
     </VStack>

--- a/src/content.ts
+++ b/src/content.ts
@@ -375,7 +375,7 @@ export const content = {
       // },
     ],
   },
-  testamonials: {
+  testimonials: {
     id: "testimonials",
     title: "What Partners Say",
     linkedInRecommendations: {

--- a/src/contexts/ScrollContext.tsx
+++ b/src/contexts/ScrollContext.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { createContext, useContext, useEffect, useRef, useState } from "react";
+
+type ScrollDirection = "up" | "down";
+
+interface ScrollContextType {
+  scrollDirection: ScrollDirection;
+}
+
+const ScrollContext = createContext<ScrollContextType | undefined>(undefined);
+
+export const ScrollProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [scrollDirection, setScrollDirection] =
+    useState<ScrollDirection>("down");
+  const lastScrollY = useRef(0);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
+      setScrollDirection(currentScrollY > lastScrollY.current ? "down" : "up");
+      lastScrollY.current = currentScrollY;
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
+
+  return (
+    <ScrollContext.Provider value={{ scrollDirection }}>
+      {children}
+    </ScrollContext.Provider>
+  );
+};
+
+export const useScrollDirection = (): ScrollDirection => {
+  const context = useContext(ScrollContext);
+  if (!context) {
+    throw new Error("useScrollDirection must be used within a ScrollProvider");
+  }
+  return context.scrollDirection;
+};

--- a/src/hooks/useFadeInOnScroll.tsx
+++ b/src/hooks/useFadeInOnScroll.tsx
@@ -1,0 +1,11 @@
+import { useScrollDirection } from "@/contexts/ScrollContext";
+
+export const useFadeInOnScroll = (inView: boolean) => {
+  const scrollDirection = useScrollDirection();
+
+  return {
+    opacity: scrollDirection === "down" ? undefined : 1,
+    className: "slide-up",
+    "data-animated": scrollDirection === "down" && inView,
+  };
+};


### PR DESCRIPTION
Changes:
- Fixes the `testamonial` typo.
- Introduces `ScrollContext` to display transition animations only when scrolling down.